### PR TITLE
Remove dep version for bson

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "body-parser": "^1.15.2",
-    "bson": "^0.2.17",
+    "bson": "*",
     "debug": "~2.1.0",
     "express": "^4.14.0",
     "fs-extra": "~0.12.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "body-parser": "^1.15.2",
-    "bson": "*",
+    "bson": "^1.0.4",
     "debug": "~2.1.0",
     "express": "^4.14.0",
     "fs-extra": "~0.12.0",


### PR DESCRIPTION
Hi - I've been trying to get a clean node dependency build for p3_user and kept hitting the problem with old version dependencies for the bson module (which won't build properly on CentOS anyway). If I make the change in this PR (along with some other dep changes in p3_user itself) I get a clean build and the warning about falling back to pure JS bson goes away.

Do you see a problem with doing this?
Thanks,
--bob